### PR TITLE
Bump dependency of illuminate/contracts to allow Laravel 11

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
         "brick/phonenumber": "^0.5.0",
         "calebporzio/sushi": "^2.4",
         "filament/filament": "^3.0",
-        "illuminate/contracts": "^10.0",
+        "illuminate/contracts": "^10.0|^11.0",
         "spatie/laravel-package-tools": "^1.15.0"
     },
     "require-dev": {

--- a/src/Columns/PhoneNumberColumn.php
+++ b/src/Columns/PhoneNumberColumn.php
@@ -95,7 +95,7 @@ class PhoneNumberColumn extends TextColumn
                     }
 
                     if (filled($numbers)) {
-                        return $query->where('phone', 'like', '%' . $numbers . '%');
+                        return $query->where($this->name, 'like', '%' . $numbers . '%');
                     } else {
                         return $query;
                     }


### PR DESCRIPTION
Hello, I was using this library for my new Laravel project and as I was checking for the viability of updating to Laravel 11 I noticed that this project had a dependency on `illuminate/contracts` version 10.x. I allowed version 11.x in the dependencies and everything continues to seem to work correctly on my end.

I am not super experienced in the PHP ecosystem, however, so it's possible I'm not doing something correctly. If I'm not, I apologize.

Thanks for considering my contribution!