### PR TITLE
Fix hardcoded column in search

### DIFF
--- a/src/Columns/PhoneNumberColumn.php
+++ b/src/Columns/PhoneNumberColumn.php
@@ -94,7 +94,7 @@ class PhoneNumberColumn extends TextColumn
                     }
 
                     if (filled($numbers)) {
-                        return $query->where('phone', 'like', '%' . $numbers . '%');
+                        return $query->where($this->getName(), 'like', '%' . $numbers . '%');
                     } else {
                         return $query;
                     }


### PR DESCRIPTION
'phone' column is hardcoded in search, Update to $this->getName() to use the filament column name.